### PR TITLE
fix: allow ucore Renovate post-upgrade task

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -7,5 +7,8 @@
   "inheritConfig": true,
   "inheritConfigRepoName": "{{parentOrg}}/renovate-config",
   "inheritConfigFileName": "org-inherited-config.json",
-  "inheritConfigStrict": true
+  "inheritConfigStrict": true,
+  "allowedCommands": [
+    "^bash ucore/ci/renovate-refresh-github-pkgs\\.sh$"
+  ]
 }


### PR DESCRIPTION
This change is required to allow our custom renovate bot to execute a postUpgradeTask which I'm using in uCore.