### PR TITLE
fix: handle 403 gracefully when app not installed on repo

### DIFF
--- a/.github/workflows/approve-renovate.yml
+++ b/.github/workflows/approve-renovate.yml
@@ -113,9 +113,19 @@ jobs:
           approve_as() {
             local token="$1" bot_login="$2" repo="$3" number="$4"
 
+            local reviews_response
+            if ! reviews_response=$(GH_TOKEN="${token}" gh api "repos/${repo}/pulls/${number}/reviews" 2>&1); then
+              if echo "${reviews_response}" | grep -qF "403"; then
+                echo "  WARN ${bot_login}: app not installed on ${repo}"
+                return 0
+              fi
+              echo "  ERROR ${bot_login}: ${reviews_response}"
+              return 1
+            fi
+
             local already_approved
             already_approved=$(
-              GH_TOKEN="${token}" gh api "repos/${repo}/pulls/${number}/reviews" \
+              echo "${reviews_response}" \
                 | jq --arg bot "${bot_login}" \
                 '[.[] | select(.user.login == $bot and .state == "APPROVED")] | length'
             )


### PR DESCRIPTION
## Summary
- Catch 403 from reviews API and log as `WARN` instead of `ERROR`
- Repos where the approve apps aren't installed no longer cause the workflow to fail
- Other API errors still reported as errors

## Context
`renovate-sandbox` (and potentially other repos) don't have the approve apps installed, causing 403 on every run and marking the workflow as failed.