### PR TITLE
fix: handle 403 on approval POST and improve error logging

### DIFF
--- a/.github/workflows/approve-renovate.yml
+++ b/.github/workflows/approve-renovate.yml
@@ -135,11 +135,16 @@ jobs:
               return 0
             fi
 
-            if GH_TOKEN="${token}" gh api "repos/${repo}/pulls/${number}/reviews" \
-              --method POST --field event=APPROVE > /dev/null 2>&1; then
+            local approve_response
+            if approve_response=$(GH_TOKEN="${token}" gh api "repos/${repo}/pulls/${number}/reviews" \
+              --method POST --field event=APPROVE 2>&1); then
               echo "  OK ${bot_login}"
             else
-              echo "  ERROR ${bot_login}: failed to approve"
+              if echo "${approve_response}" | grep -qF "403"; then
+                echo "  WARN ${bot_login}: no write access to ${repo}"
+                return 0
+              fi
+              echo "  ERROR ${bot_login}: ${approve_response}"
               return 1
             fi
           }


### PR DESCRIPTION
## Summary
- Catch 403 on the approval POST (not just the reviews GET)
- Log actual API error response instead of generic "failed to approve"
- 403 on POST logs `WARN: no write access` and doesn't fail the workflow

## Context
PR #63 only caught 403 on the reviews GET. The GET succeeds (read access) but the POST fails with 403 (no write access) for repos where the app isn't fully installed.